### PR TITLE
nv2a: Handle 2D textures given to 3D texture modes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,18 +1,13 @@
 name: Build
 
 on:
-  push:
-    paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/build.yml'
-      - 'README.md'
-      - 'ubuntu-win64-cross/**'
   pull_request:
     paths-ignore:
       - '.github/**'
       - '!.github/workflows/build.yml'
       - 'README.md'
       - 'ubuntu-win64-cross/**'
+  workflow_dispatch:
 
 jobs:
   Init:
@@ -25,26 +20,6 @@ jobs:
         fetch-depth: 0
     - name: Install dependencies
       run: sudo apt-get install meson
-    # On push to master, increment patch version and create a new tag on release
-    - name: Increment patch version
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-      run: |
-        git config user.name "nobody"
-        git config user.email "nobody@nowhere"
-        VERSION=$(git describe --tags --match 'v*' --abbrev=0 | xargs ./scripts/increment-semver.py)
-        git tag -a $VERSION -m $VERSION
-        echo "Generated new release version: $VERSION"
-    # GitHub treats the new tag as lightweight, so older tags will shadow the
-    # new tag. Recreate it as an annotated tag now so the version script picks
-    # it up properly.
-    - name: Annotate release tag
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-      run: |
-        git config user.name "nobody"
-        git config user.email "nobody@nowhere"
-        VERSION=${GITHUB_REF/refs\/tags\//}
-        git tag -a -f $VERSION $VERSION -m $VERSION
-        echo "Recreated release tag: $VERSION"
     - name: Create source package
       run: |
         ./scripts/archive-source.sh src.tar
@@ -62,21 +37,13 @@ jobs:
     strategy:
       matrix:
         include:
-        - configuration: Debug
-          build_param: --debug
-          artifact_name: xemu-win-x86_64-debug
+        - configuration: DebugRenderDoc
+          build_param:  --debug --enable-renderdoc
+          artifact_name: xemu-win-x86_64-debugrenderdoc
           arch: x86_64
-        - configuration: Release
-          build_param:
-          artifact_name: xemu-win-x86_64-release
-          arch: x86_64
-        - configuration: Debug
-          build_param: --debug
-          artifact_name: xemu-win-aarch64-debug
-          arch: aarch64
-        - configuration: Release
-          build_param:
-          artifact_name: xemu-win-aarch64-release
+        - configuration: DebugRenderDoc
+          build_param:  --debug --enable-renderdoc
+          artifact_name: xemu-win-aarch64-debugrenderdoc
           arch: aarch64
     env:
       DOCKER_IMAGE_NAME: ghcr.io/xemu-project/xemu-win64-toolchain:sha-0d06ce8
@@ -109,57 +76,11 @@ jobs:
           -e CROSSAR=${{ matrix.arch }}-w64-mingw32.static-ar \
           -u $(id -u):$(id -g) \
           $DOCKER_IMAGE_NAME \
-            bash -c "ccache -z; ./build.sh -p win64-cross ${{ matrix.build_param }} && ccache -s"
+            bash -c "ccache -z;export CFLAGS=\"${CFLAGS} -DDEBUG_NV2A_GL=1 -DSTREAM_GL_DEBUG_MESSAGES=1\"; ./build.sh -p win64-cross ${{ matrix.build_param }} && ccache -s"
     - name: Upload build artifact
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ matrix.artifact_name }}
-        path: dist
-
-  # Generate a symbols package for Windows. Use cv2pdb to generate PDBs from
-  # DWARF and update + strip the executable. Re-package the original release
-  # and create symbols package.
-  WindowsPdb:
-    name: Generate PDB for Windows (${{ matrix.arch }}, ${{ matrix.configuration }})
-    runs-on: windows-latest
-    needs: Windows
-    strategy:
-      matrix:
-        include:
-        - configuration: Debug
-          artifact_name: xemu-win-x86_64-debug
-          arch: x86_64
-        - configuration: Release
-          artifact_name: xemu-win-x86_64-release
-          arch: x86_64
-        - configuration: Debug
-          artifact_name: xemu-win-aarch64-debug
-          arch: aarch64
-        - configuration: Release
-          artifact_name: xemu-win-aarch64-release
-          arch: aarch64
-    steps:
-    - name: Download artifacts
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4
-      with:
-        name: ${{ matrix.artifact_name }}
-        path: ${{ matrix.artifact_name }}
-    - name: Generate PDB
-      run: |
-        Invoke-WebRequest -Uri "https://github.com/rainers/cv2pdb/releases/download/v0.52/cv2pdb-0.52.zip" -OutFile "cv2pdb.zip"
-        Invoke-WebRequest -Uri "https://github.com/mstorsjo/llvm-mingw/releases/download/20241217/llvm-mingw-20241217-ucrt-x86_64.zip" -OutFile "llvm-mingw.zip"
-        7z x -ocv2pdb -y cv2pdb.zip
-        7z x -y llvm-mingw.zip
-        cd ${{ matrix.artifact_name }}
-        ../cv2pdb/cv2pdb64.exe xemu.exe
-        ../llvm-mingw-20241217-ucrt-x86_64/bin/${{ matrix.arch }}-w64-mingw32-strip.exe xemu.exe
-        mkdir ../dist
-        7z a -tzip ../dist/${{ matrix.artifact_name }}.zip * "-xr!*.pdb"
-        7z a -tzip ../dist/${{ matrix.artifact_name }}-pdb.zip "-ir!*.pdb"
-    - name: Upload build artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: ${{ matrix.artifact_name }}-pdb
         path: dist
 
   Ubuntu:
@@ -170,29 +91,17 @@ jobs:
       matrix:
         include:
         - arch: x86_64
-          configuration: Debug
-          build_param: --debug
-          artifact_name: xemu-ubuntu-x86_64-debug
-          artifact_filename: xemu-ubuntu-x86_64-debug.tgz
-          runs-on: ubuntu-22.04
-        - arch: x86_64
-          configuration: Release
-          build_param:
-          artifact_name: xemu-ubuntu-x86_64-release
-          artifact_filename: xemu-ubuntu-x86_64-release.tgz
+          configuration: DebugRenderDoc
+          build_param: --debug --enable-renderdoc
+          artifact_name: xemu-ubuntu-x86_64-debugrenderdoc
+          artifact_filename: xemu-ubuntu-x86_64-debugrenderdoc.tgz
           runs-on: ubuntu-22.04
         - arch: aarch64
-          configuration: Debug
-          build_param: --debug
-          artifact_name: xemu-ubuntu-aarch64-debug
-          artifact_filename: xemu-ubuntu-aarch64-debug.tgz
-          runs-on: ubuntu-22.04-arm
-        - arch: aarch64
-          configuration: Release
-          build_param:
-          artifact_name: xemu-ubuntu-aarch64-release
-          artifact_filename: xemu-ubuntu-aarch64-release.tgz
-          runs-on: ubuntu-22.04-arm
+          configuration: DebugRenderDoc
+          build_param: --debug --enable-renderdoc
+          artifact_name: xemu-ubuntu-aarch64-debugrenderdoc
+          artifact_filename: xemu-ubuntu-aarch64-debugrenderdoc.tgz
+          runs-on: ubuntu-24.02-arm
     steps:
     - name: Initialize compiler cache
       id: cache
@@ -229,6 +138,7 @@ jobs:
         export CCACHE_DIR=/tmp/xemu-ccache
         export CCACHE_MAXSIZE=512M
         export PATH="/usr/lib/ccache:$PATH"
+        export CFLAGS="-DDEBUG_NV2A_GL=1 -DSTREAM_GL_DEBUG_MESSAGES=1"
         export XEMU_BUILD_OPTIONS="${{ matrix.build_param }}"
         ccache -z
 
@@ -260,10 +170,7 @@ jobs:
         tar -C appimage -xf data.tar*
         install -DT src/xemu.metainfo.xml appimage/usr/share/metainfo/xemu.metainfo.xml
 
-        export VERSION=v$(cat src/XEMU_VERSION)
-        if [[ "${{ matrix.configuration }}" == "Debug" ]]; then
-          export VERSION=$VERSION-dbg
-        fi
+        export VERSION=v$(cat src/XEMU_VERSION)-abaire
 
         ./linuxdeploy-${{ matrix.arch }}.AppImage --output appimage --appdir appimage
         mv xemu-*.AppImage dist
@@ -275,215 +182,3 @@ jobs:
       with:
         name: ${{ matrix.artifact_name }}
         path: ${{ matrix.artifact_filename }}
-
-  macOS:
-    name: Build for macOS (${{ matrix.arch }}, ${{ matrix.configuration }})
-    runs-on: macOS-14
-    needs: Init
-    strategy:
-      matrix:
-        include:
-        - arch: x86_64
-          configuration: Debug
-          build_param: --debug -a x86_64
-          artifact_name: xemu-macos-x86_64-debug
-          artifact_filename: xemu-macos-x86_64-debug.zip
-        - arch: x86_64
-          configuration: Release
-          build_param: -a x86_64
-          artifact_name: xemu-macos-x86_64-release
-          artifact_filename: xemu-macos-x86_64-release.zip
-        - arch: arm64
-          configuration: Debug
-          build_param: --debug -a arm64
-          artifact_name: xemu-macos-arm64-debug
-          artifact_filename: xemu-macos-arm64-debug.zip
-        - arch: arm64
-          configuration: Release
-          build_param: -a arm64
-          artifact_name: xemu-macos-arm64-release
-          artifact_filename: xemu-macos-arm64-release.zip
-    steps:
-    - name: Download source package
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4
-      with:
-        name: src.tar.gz
-    - name: Extract source package
-      run: tar xf src.tar.gz
-    - uses: actions/setup-python@v6.0.0
-      with:
-        python-version: '3.12'
-    - name: Install dependencies
-      run: |
-        export HOMEBREW_NO_AUTO_UPDATE=1
-        export HOMEBREW_NO_INSTALL_CLEANUP=1
-        brew install \
-          ccache \
-          coreutils \
-          dylibbundler
-        pip install pyyaml requests
-    - name: Initialize compiler, library cache
-      id: cache
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-      with:
-        path: |
-          xemu-ccache
-          macos-pkgs
-        key: cache-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-${{ github.sha }}
-        restore-keys: cache-${{ runner.os }}-${{ matrix.arch }}-${{ matrix.configuration }}-
-    - name: Compile
-      run: |
-        export CCACHE_DIR=${GITHUB_WORKSPACE}/xemu-ccache
-        export CCACHE_MAXSIZE=512M
-        export PATH="/usr/local/opt/ccache/libexec:$PATH"
-        ccache -z
-        ./build.sh ${{ matrix.build_param }}
-        echo -e "\nCompiler Cache Stats:"
-        ccache -s
-        pushd dist
-        zip -r ../${{ matrix.artifact_filename }} *
-        popd
-    - name: Upload build artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: ${{ matrix.artifact_name }}
-        path: ${{ matrix.artifact_filename }}
-
-  macOSUniversal:
-    name: Build macOS Universal Bundle (${{ matrix.configuration }})
-    runs-on: macOS-14
-    needs: [macOS]
-    strategy:
-      matrix:
-        configuration: ["debug", "release"]
-    steps:
-    - name: Download x86_64 build
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4
-      with:
-        name: xemu-macos-x86_64-${{ matrix.configuration }}
-        path: xemu-macos-x86_64-${{ matrix.configuration }}
-    - name: Download arm64 build
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4
-      with:
-        name: xemu-macos-arm64-${{ matrix.configuration }}
-        path: xemu-macos-arm64-${{ matrix.configuration }}
-    - name: Build Universal bundle
-      run: |
-        mkdir dist
-        for arch in x86_64 arm64; do
-          pushd xemu-macos-${arch}-${{ matrix.configuration }}
-          unzip xemu-macos-${arch}-${{ matrix.configuration }}.zip
-          popd
-          pushd dist
-          unzip -o ../xemu-macos-${arch}-${{ matrix.configuration }}/xemu-macos-${arch}-${{ matrix.configuration }}.zip
-          popd
-        done
-        pushd dist
-        rm xemu.app/Contents/MacOS/xemu
-        lipo -create -output xemu.app/Contents/MacOS/xemu \
-          ../xemu-macos-x86_64-${{ matrix.configuration }}/xemu.app/Contents/MacOS/xemu \
-          ../xemu-macos-arm64-${{ matrix.configuration }}/xemu.app/Contents/MacOS/xemu
-        codesign --force --deep --preserve-metadata=entitlements,requirements,flags,runtime --sign - xemu.app/Contents/MacOS/xemu
-        zip -r ../xemu-macos-universal-${{ matrix.configuration }}.zip *
-        popd
-    - name: Upload build artifact
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      with:
-        name: xemu-macos-universal-${{ matrix.configuration }}
-        path: xemu-macos-universal-${{ matrix.configuration }}.zip
-
-  Release:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
-    runs-on: ubuntu-latest
-    needs: [Ubuntu, macOSUniversal, Windows, WindowsPdb]
-    steps:
-    - name: Download artifacts
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4
-      with:
-        path: dist
-    - name: Extract source package
-      run: tar xf dist/src.tar.gz/src.tar.gz
-    - name: Get release info
-      run: |
-        echo "XEMU_VERSION=$(cat XEMU_VERSION)" >> $GITHUB_ENV
-    - name: Extract Ubuntu artifacts
-      run: |
-        for arch in x86_64 aarch64; do
-          for config in release debug; do
-            pushd dist/xemu-ubuntu-$arch-$config
-            tar xvf xemu-ubuntu-$arch-$config.tgz
-            popd
-          done
-        done
-    # Architecture tags were recently added to the Windows release path. Provide an alias with the former name for a while.
-    - name: Add transitionary package alias
-      run: |
-        cp dist/xemu-win-x86_64-release-pdb/xemu-win-x86_64-release.zip dist/xemu-win-x86_64-release-pdb/xemu-win-release.zip
-    - name: Publish release
-      uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
-      with:
-        tag_name: v${{ env.XEMU_VERSION }}
-        name: v${{ env.XEMU_VERSION }}
-        prerelease: false
-        draft: false
-        files: |
-          dist/src.tar.gz/src.tar.gz
-          dist/xemu-win-aarch64-debug-pdb/xemu-win-aarch64-debug.zip
-          dist/xemu-win-aarch64-debug-pdb/xemu-win-aarch64-debug-pdb.zip
-          dist/xemu-win-aarch64-release-pdb/xemu-win-aarch64-release.zip
-          dist/xemu-win-aarch64-release-pdb/xemu-win-aarch64-release-pdb.zip
-          dist/xemu-win-x86_64-debug-pdb/xemu-win-x86_64-debug.zip
-          dist/xemu-win-x86_64-debug-pdb/xemu-win-x86_64-debug-pdb.zip
-          dist/xemu-win-x86_64-release-pdb/xemu-win-x86_64-release.zip
-          dist/xemu-win-x86_64-release-pdb/xemu-win-x86_64-release-pdb.zip
-          dist/xemu-win-x86_64-release-pdb/xemu-win-release.zip
-          dist/xemu-macos-universal-release/xemu-macos-universal-release.zip
-          dist/xemu-macos-universal-debug/xemu-macos-universal-debug.zip
-          dist/xemu-ubuntu-x86_64-debug/xemu/xemu-v${{ env.XEMU_VERSION }}-dbg-x86_64.AppImage
-          dist/xemu-ubuntu-x86_64-release/xemu/xemu-v${{ env.XEMU_VERSION }}-x86_64.AppImage
-          dist/xemu-ubuntu-aarch64-debug/xemu/xemu-v${{ env.XEMU_VERSION }}-dbg-aarch64.AppImage
-          dist/xemu-ubuntu-aarch64-release/xemu/xemu-v${{ env.XEMU_VERSION }}-aarch64.AppImage
-    - name: Trigger website update
-      uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4
-      with:
-        workflow: build.yml
-        repo: xemu-project/xemu-website
-        token: ${{ secrets.XEMU_ROBOT_TOKEN }}
-        ref: master
-
-  # Sync archive version of source (including submodule code) to the
-  # ppa-snapshot branch to work around limitations of the Launchpad platform,
-  # namely: no network egress on package build, no custom scripting in source
-  # package creation.
-  PushToPPA:
-    name: Push to PPA Snapshot Branch
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
-    needs: [Ubuntu, macOSUniversal, Windows, WindowsPdb]
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download source package
-      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4
-      with:
-        name: src.tar.gz
-    - name: Extract source package
-      run: |
-        mkdir src
-        tar -C src -xf src.tar.gz
-
-        # Ensure subprojects are uploaded
-        find src/subprojects -name "*.gitignore" -exec rm {} \;
-    - name: Integrate Debian packaging
-      run: |
-        pushd src
-        echo -e "\
-        xemu (1:$(cat XEMU_VERSION)-0) unstable; urgency=medium\n\
-          Built from $(cat XEMU_VERSION)\n\
-         -- Matt Borgerson <contact@mborgerson.com>  $(date -R)" > debian/changelog
-        popd
-    - name: Deploy source archive to branch
-      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./src
-        publish_branch: ppa-snapshot
-        force_orphan: true

--- a/build.sh
+++ b/build.sh
@@ -161,7 +161,7 @@ done
 
 target="qemu-system-i386"
 if test ! -z "$debug"; then
-    build_cflags='-DXEMU_DEBUG_BUILD=1'
+    build_cflags='-O0 -g3 -DXEMU_DEBUG_BUILD=1'
     opts="--enable-debug --enable-trace-backends=log"
 fi
 

--- a/hmp-commands.hx
+++ b/hmp-commands.hx
@@ -450,6 +450,33 @@ SRST
   Start gdbserver session (default *port*\=1234)
 ERST
 
+
+    {
+        .name       = "s",
+        .args_type  = "start:l,end:l,data:s,type:s,",
+        .params     = "start end data type",
+        .help       = "search virtual memory between 'start' and 'end' for 'data' (which is of 'type').",
+        .cmd = hmp_memory_search,
+    },
+
+SRST
+``s/``\ *fmt* *addr* *data*
+  Search virtual memory starting at *addr* for *data*.
+ERST
+
+    {
+        .name       = "sp",
+        .args_type  = "start:l,end:l,data:s,type:s,",
+        .params     = "start end data type",
+        .help       = "search physical memory between 'start' and 'end' for 'data' (which is of 'type').",
+        .cmd = hmp_physical_memory_search,
+    },
+
+SRST
+``s/``\ *fmt* *addr* *data*
+  Search physical memory starting at *addr* for *data*.
+ERST
+
     {
         .name       = "x",
         .args_type  = "fmt:/,addr:l",

--- a/hw/xbox/nv2a/pgraph/gl/debug.c
+++ b/hw/xbox/nv2a/pgraph/gl/debug.c
@@ -46,6 +46,97 @@
 static bool has_GL_GREMEDY_frame_terminator = false;
 static bool has_GL_KHR_debug = false;
 
+#ifdef STREAM_GL_DEBUG_MESSAGES
+
+static const char *gl_debug_type_names[] = {
+        "ERROR",
+        "DEPRECATED",
+        "UNDEFINED",
+        "PORTABILITY",
+        "PERFORMANCE",
+        "MARKER",
+        "PUSH_GROUP",
+        "POP_GROUP",
+        "OTHER",
+};
+
+static const char *gl_debug_severity_names[] = {
+        "HIGH",
+        "MEDIUM",
+        "LOW",
+        "NOTIFICATION",
+};
+
+static void APIENTRY print_gl_debug_message(GLenum /*source*/, GLenum type,
+                                            GLuint id, GLenum severity,
+                                            GLsizei length,
+                                            const GLchar *message,
+                                            const void *userParam)
+{
+    const char *type_name = "<UNKNOWN>";
+    const char *severity_name = "<UNKNOWN>";
+
+    if (type != GL_DEBUG_TYPE_ERROR) {
+        return;
+    }
+
+    switch (type) {
+        default:
+            break;
+        case GL_DEBUG_TYPE_ERROR:
+            type_name = gl_debug_type_names[0];
+            break;
+        case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR:
+            type_name = gl_debug_type_names[1];
+            break;
+        case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:
+            type_name = gl_debug_type_names[2];
+            break;
+        case GL_DEBUG_TYPE_PORTABILITY:
+            type_name = gl_debug_type_names[3];
+            break;
+        case GL_DEBUG_TYPE_PERFORMANCE:
+            type_name = gl_debug_type_names[4];
+            break;
+        case GL_DEBUG_TYPE_MARKER:
+            type_name = gl_debug_type_names[5];
+            break;
+        case GL_DEBUG_TYPE_PUSH_GROUP:
+            type_name = gl_debug_type_names[6];
+            break;
+        case GL_DEBUG_TYPE_POP_GROUP:
+            type_name = gl_debug_type_names[7];
+            break;
+        case GL_DEBUG_TYPE_OTHER:
+            type_name = gl_debug_type_names[8];
+            break;
+    }
+
+    switch (severity) {
+        default:
+            break;
+        case GL_DEBUG_SEVERITY_HIGH:
+            severity_name = gl_debug_severity_names[0];
+            break;
+        case GL_DEBUG_SEVERITY_MEDIUM:
+            severity_name = gl_debug_severity_names[1];
+            break;
+        case GL_DEBUG_SEVERITY_LOW:
+            severity_name = gl_debug_severity_names[2];
+            break;
+        case GL_DEBUG_SEVERITY_NOTIFICATION:
+            severity_name = gl_debug_severity_names[3];
+            break;
+    }
+
+    if (length < 0) {
+        fprintf(stderr,"GLDBG[%s][%s]> %s\n", type_name, severity_name, message);
+    } else {
+        fprintf(stderr,"GLDBG[%s][%s]> %*s\n", type_name, severity_name, length, message);
+    }
+}
+#endif
+
 void gl_debug_initialize(void)
 {
     has_GL_KHR_debug = glo_check_extension("GL_KHR_debug");
@@ -64,8 +155,12 @@ void gl_debug_initialize(void)
          * so skip the call for this platform.
          */
 #else
-       glEnable(GL_DEBUG_OUTPUT);
-       assert(glGetError() == GL_NO_ERROR);
+        glEnable(GL_DEBUG_OUTPUT);
+        assert(glGetError() == GL_NO_ERROR);
+#endif
+
+#ifdef STREAM_GL_DEBUG_MESSAGES
+        glDebugMessageCallback(print_gl_debug_message, NULL);
 #endif
     }
 

--- a/hw/xbox/nv2a/pgraph/gl/debug.h
+++ b/hw/xbox/nv2a/pgraph/gl/debug.h
@@ -31,6 +31,8 @@
 #include "gloffscreen.h"
 #include "config-host.h"
 
+extern uint32_t g_nv2a_current_frame_draw_count;  // abaire
+
 void gl_debug_initialize(void);
 void gl_debug_message(bool cc, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 void gl_debug_group_begin(const char *fmt, ...) __attribute__ ((format (printf, 1, 2)));

--- a/hw/xbox/nv2a/pgraph/gl/draw.c
+++ b/hw/xbox/nv2a/pgraph/gl/draw.c
@@ -127,7 +127,7 @@ void pgraph_gl_clear_surface(NV2AState *d, uint32_t parameter)
     if (r->zeta_binding) {
         r->zeta_binding->cleared = full_clear && write_zeta;
     }
-    
+
     pg->clearing = false;
 }
 
@@ -136,7 +136,16 @@ void pgraph_gl_draw_begin(NV2AState *d)
     PGRAPHState *pg = &d->pgraph;
     PGRAPHGLState *r = pg->gl_renderer_state;
 
-    NV2A_GL_DGROUP_BEGIN("NV097_SET_BEGIN_END: 0x%x", pg->primitive_mode);
+    // abaire
+#if DEBUG_NV2A_GL
+    NV2A_GL_DGROUP_BEGIN("NV097_SET_BEGIN_END: 0x%x %d", pg->primitive_mode, g_nv2a_current_frame_draw_count);
+    {
+        char buffer[256] = {0};
+        sprintf(buffer, "frame_draw %d   ", g_nv2a_current_frame_draw_count);
+        trace_nv2a_pgraph_method(-1, 0, 0, buffer, 0, 0);
+    }
+#endif
+    // /abaire
 
     uint32_t control_0 = pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0);
     bool mask_alpha = control_0 & NV_PGRAPH_CONTROL_0_ALPHA_WRITE_ENABLE;
@@ -365,6 +374,10 @@ void pgraph_gl_draw_end(NV2AState *d)
 {
     PGRAPHState *pg = &d->pgraph;
     PGRAPHGLState *r = pg->gl_renderer_state;
+
+#if DEBUG_NV2A_GL
+    ++g_nv2a_current_frame_draw_count;  // abaire
+#endif
 
     uint32_t control_0 = pgraph_reg_r(pg, NV_PGRAPH_CONTROL_0);
     bool mask_alpha = control_0 & NV_PGRAPH_CONTROL_0_ALPHA_WRITE_ENABLE;

--- a/hw/xbox/nv2a/pgraph/glsl/psh.c
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.c
@@ -134,6 +134,7 @@ void pgraph_glsl_set_psh_state(PGRAPHState *pg, PshState *state)
         uint32_t border_source =
             GET_MASK(tex_fmt, NV_PGRAPH_TEXFMT0_BORDER_SOURCE);
         bool cubemap = GET_MASK(tex_fmt, NV_PGRAPH_TEXFMT0_CUBEMAPENABLE);
+        state->tex_cubemap[i] = cubemap;
         state->border_logical_size[i][0] = 0.0f;
         state->border_logical_size[i][1] = 0.0f;
         state->border_logical_size[i][2] = 0.0f;
@@ -607,13 +608,13 @@ static const char *get_sampler_type(struct PixelShader *ps, enum PS_TEXTUREMODES
         return NULL;
 
     case PS_TEXTUREMODES_PROJECT2D:
-        if (state->dim_tex[i] == 2) {
+        if (dim == 2) {
             if (state->tex_x8y24[i] && ps->opts.vulkan) {
                 return "usampler2D";
             }
             return sampler2D;
         }
-        if (state->dim_tex[i] == 3) return sampler3D;
+        if (dim == 3) return sampler3D;
         assert(!"Unhandled texture dimensions");
         return NULL;
 
@@ -624,8 +625,8 @@ static const char *get_sampler_type(struct PixelShader *ps, enum PS_TEXTUREMODES
             fprintf(stderr, "Shadow map support not implemented for mode %d\n", mode);
             assert(!"Shadow map support not implemented for this mode");
         }
-        if (state->dim_tex[i] == 2) return sampler2D;
-        if (state->dim_tex[i] == 3 && mode != PS_TEXTUREMODES_DOT_ST) return sampler3D;
+        if (dim == 2) return sampler2D;
+        if (dim == 3 && mode != PS_TEXTUREMODES_DOT_ST) return sampler3D;
         assert(!"Unhandled texture dimensions");
         return NULL;
 
@@ -647,8 +648,11 @@ static const char *get_sampler_type(struct PixelShader *ps, enum PS_TEXTUREMODES
             fprintf(stderr, "Shadow map support not implemented for mode %d\n", mode);
             assert(!"Shadow map support not implemented for this mode");
         }
-        assert(state->dim_tex[i] == 2);
-        return samplerCube;
+        assert(dim == 2);
+        if (state->tex_cubemap[i]) {
+            return samplerCube;
+        }
+        return sampler2D;
 
     case PS_TEXTUREMODES_DPNDNT_AR:
     case PS_TEXTUREMODES_DPNDNT_GB:
@@ -656,7 +660,7 @@ static const char *get_sampler_type(struct PixelShader *ps, enum PS_TEXTUREMODES
             fprintf(stderr, "Shadow map support not implemented for mode %d\n", mode);
             assert(!"Shadow map support not implemented for this mode");
         }
-        assert(state->dim_tex[i] == 2);
+        assert(dim == 2);
         return sampler2D;
     }
 }
@@ -883,6 +887,41 @@ static MString* psh_convert(struct PixelShader *ps)
         "    vec2(-1.0,-1.0),vec2(0.0,-1.0),vec2(1.0,-1.0),\n"
         "    vec2(-1.0, 0.0),vec2(0.0, 0.0),vec2(1.0, 0.0),\n"
         "    vec2(-1.0, 1.0),vec2(0.0, 1.0),vec2(1.0, 1.0));\n"
+        "vec2 remapCubeTo2D(vec3 texCoord) {\n"
+        "    vec2 uv;\n"
+        "    vec3 absTexCoord = abs(texCoord);\n"
+        "    if (absTexCoord.x > absTexCoord.y && absTexCoord.x > absTexCoord.z) {\n"
+        "        if (texCoord.x > 0.0) {\n"
+        "            // +X: Right\n"
+        "            uv = vec2(-texCoord.z, texCoord.y);\n"
+        "        } else {\n"
+        "            // -X: Left\n"
+        "            uv = vec2(texCoord.z, texCoord.y);\n"
+        "        }\n"
+        "        uv /= absTexCoord.x;\n"
+        "    }\n"
+        "    else if (absTexCoord.y > absTexCoord.x && absTexCoord.y > absTexCoord.z) {\n"
+        "        if (texCoord.y > 0.0) {\n"
+        "            // +Y: Top\n"
+        "            uv = vec2(texCoord.x, -texCoord.z);\n"
+        "        } else {\n"
+        "            // -Y: Bottom\n"
+        "            uv = vec2(texCoord.x, texCoord.z);\n"
+        "        }\n"
+        "        uv /= absTexCoord.y;\n"
+        "    }\n"
+        "    else {\n"
+        "        if (texCoord.z > 0.0) {\n"
+        "            // +Z: Front\n"
+        "            uv = vec2(texCoord.x, texCoord.y);\n"
+        "        } else {\n"
+        "            // -Z: Back\n"
+        "            uv = vec2(-texCoord.x, texCoord.y);\n"
+        "        }\n"
+        "        uv /= absTexCoord.z;\n"
+        "    }\n"
+        "    return uv;\n"
+        "}\n"
         );
 
     MString *clip = mstring_new();
@@ -1028,8 +1067,14 @@ static MString* psh_convert(struct PixelShader *ps)
             }
             break;
         case PS_TEXTUREMODES_CUBEMAP:
-            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, pT%d.xyz);\n",
-                               i, i, i);
+            if (!ps->state->tex_cubemap[i]) {
+                mstring_append_fmt(vars,
+                    "pT%d.xy = remapCubeTo2D(pT%d.xyz);\n",
+                    i, i);
+            }
+            mstring_append_fmt(vars,
+                "vec4 t%d = texture(texSamp%d, pT%d.xy%s);\n",
+                i, i, i, ps->state->tex_cubemap[i] ? "z" : "");
             break;
         case PS_TEXTUREMODES_PASSTHRU:
             assert(ps->state->border_logical_size[i][0] == 0.0f && "Unexpected border texture on passthru");
@@ -1139,8 +1184,13 @@ static MString* psh_convert(struct PixelShader *ps)
             mstring_append_fmt(vars, "vec3 n_%d = vec3(dot%d, dot%d, dot%d_n);\n",
                 i, i-1, i, i);
             apply_border_adjustment(ps, vars, i, "n_%d");
-            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, n_%d);\n",
-                i, i, i);
+            if (!ps->state->tex_cubemap[i]) {
+                mstring_append_fmt(vars,
+                    "n_%d.xy = remapCubeTo2D(n_%d);\n", i, i);
+            }
+            mstring_append_fmt(vars,
+                "vec4 t%d = texture(texSamp%d, n_%d%s);\n",
+                i, i, i, ps->state->tex_cubemap[i] ? "" : ".xy");
             break;
         case PS_TEXTUREMODES_DOT_RFLCT_SPEC:
             assert(i == 3);
@@ -1154,8 +1204,13 @@ static MString* psh_convert(struct PixelShader *ps)
             mstring_append_fmt(vars, "vec3 rv_%d = 2*n_%d*dot(n_%d,e_%d)/dot(n_%d,n_%d) - e_%d;\n",
                 i, i, i, i, i, i, i);
             apply_border_adjustment(ps, vars, i, "rv_%d");
-            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, rv_%d);\n",
-                i, i, i);
+            if (!ps->state->tex_cubemap[i]) {
+                mstring_append_fmt(vars,
+                    "rv_%d.xy = remapCubeTo2D(rv_%d);\n", i, i);
+            }
+            mstring_append_fmt(vars,
+                "vec4 t%d = texture(texSamp%d, rv_%d%s);\n",
+                i, i, i, ps->state->tex_cubemap[i] ? "" : ".xy");
             break;
         case PS_TEXTUREMODES_DOT_STR_3D:
             assert(i == 3);
@@ -1167,7 +1222,8 @@ static MString* psh_convert(struct PixelShader *ps)
                 i, i-2, i-1, i);
 
             apply_border_adjustment(ps, vars, i, "dotSTR%d");
-            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, %s(dotSTR%d%s));\n",
+            mstring_append_fmt(vars,
+                "vec4 t%d = texture(texSamp%d, %s(dotSTR%d%s));\n",
                 i, i, tex_remap, i, ps->state->dim_tex[i] == 2 ? ".xy" : "");
             break;
         case PS_TEXTUREMODES_DOT_STR_CUBE:
@@ -1178,8 +1234,14 @@ static MString* psh_convert(struct PixelShader *ps)
             mstring_append_fmt(vars, "vec3 dotSTR%dCube = vec3(dot%d, dot%d, dot%d);\n",
                                i, i-2, i-1, i);
             apply_border_adjustment(ps, vars, i, "dotSTR%dCube");
-            mstring_append_fmt(vars, "vec4 t%d = texture(texSamp%d, dotSTR%dCube);\n",
-                i, i, i);
+            if (!ps->state->tex_cubemap[i]) {
+                mstring_append_fmt(vars,
+                    "dotSTR%dCube.xy = remapCubeTo2D(dotSTR%dCube);\n",
+                    i, i);
+            }
+            mstring_append_fmt(vars,
+                "vec4 t%d = texture(texSamp%d, dotSTR%dCube%s);\n",
+                i, i, i, ps->state->tex_cubemap[i] ? "" : ".xy");
             break;
         case PS_TEXTUREMODES_DPNDNT_AR:
             assert(i >= 1);

--- a/hw/xbox/nv2a/pgraph/glsl/psh.h
+++ b/hw/xbox/nv2a/pgraph/glsl/psh.h
@@ -46,6 +46,7 @@ typedef struct PshState {
     enum ConvolutionFilter conv_tex[4];
     bool tex_x8y24[4];
     int dim_tex[4];
+    bool tex_cubemap[4];
 
     float border_logical_size[4][3];
     float border_inv_real_size[4][3];

--- a/hw/xbox/nv2a/pgraph/profile.c
+++ b/hw/xbox/nv2a/pgraph/profile.c
@@ -20,6 +20,7 @@
 #include "hw/xbox/nv2a/nv2a_int.h"
 
 NV2AStats g_nv2a_stats;
+uint32_t g_nv2a_current_frame_draw_count = 0;  // abaire
 
 void nv2a_profile_increment(void)
 {
@@ -51,6 +52,8 @@ void nv2a_profile_flip_stall(void)
         (g_nv2a_stats.frame_ptr + 1) % NV2A_PROF_NUM_FRAMES;
     g_nv2a_stats.frame_count++;
     memset(&g_nv2a_stats.frame_working, 0, sizeof(g_nv2a_stats.frame_working));
+
+    g_nv2a_current_frame_draw_count = 0;  // abaire
 }
 
 const char *nv2a_profile_get_counter_name(unsigned int cnt)

--- a/include/monitor/hmp-target.h
+++ b/include/monitor/hmp-target.h
@@ -55,6 +55,8 @@ void hmp_info_sev(Monitor *mon, const QDict *qdict);
 void hmp_info_sgx(Monitor *mon, const QDict *qdict);
 void hmp_info_via(Monitor *mon, const QDict *qdict);
 void hmp_memory_dump(Monitor *mon, const QDict *qdict);
+void hmp_memory_search(Monitor *mon, const QDict *qdict);
+void hmp_physical_memory_search(Monitor *mon, const QDict *qdict);
 void hmp_physical_memory_dump(Monitor *mon, const QDict *qdict);
 void hmp_info_registers(Monitor *mon, const QDict *qdict);
 void hmp_gva2gpa(Monitor *mon, const QDict *qdict);

--- a/target/i386/tcg/sysemu/excp_helper.c
+++ b/target/i386/tcg/sysemu/excp_helper.c
@@ -646,6 +646,16 @@ bool x86_cpu_tlb_fill(CPUState *cs, vaddr addr, int size,
     } else {
         env->cr[2] = err.cr2;
     }
+
+#ifdef XBOX
+    fprintf(stderr,
+            "MMU fault: ExceptionIndex: EXCP%02X ErrorCode: %d ReturnAddr: %lX EIP: %X\n",
+            cs->exception_index,
+            env->error_code,
+            retaddr,
+            env->eip);
+#endif
+
     raise_exception_err_ra(env, err.exception_index, err.error_code, retaddr);
 }
 

--- a/ui/xui/menubar.cc
+++ b/ui/xui/menubar.cc
@@ -29,6 +29,10 @@
 #include "update.hh"
 #include "../xemu-os-utils.h"
 
+extern "C" {
+#include "trace/control.h"
+}
+
 extern float g_main_menu_height; // FIXME
 
 #ifdef CONFIG_RENDERDOC
@@ -69,6 +73,25 @@ void ProcessKeyboardShortcuts(void)
 
     if (ImGui::IsKeyPressed(ImGuiKey_F12)) {
         ActionScreenshot();
+    }
+
+    if (ImGui::IsKeyPressed(ImGuiKey_F9)) {
+        // TODO: Look up current state of nv2a traces and init this var.
+        static bool pgraph_trace_state = false;
+        pgraph_trace_state = !pgraph_trace_state;
+        static const char *nv2a_pgraph_enable = "nv2a_pgraph_*";
+        static const char *nv2a_pgraph_disable = "-nv2a_pgraph_*";
+        trace_enable_events(pgraph_trace_state ? nv2a_pgraph_enable :
+                                                 nv2a_pgraph_disable);
+
+        static const char *nv2a_reg_enable = "nv2a_reg_write*";
+        static const char *nv2a_reg_disable = "-nv2a_reg_write*";
+        ImGuiIO& io = ImGui::GetIO();
+        if (pgraph_trace_state && io.KeyShift) {
+            trace_enable_events(nv2a_reg_enable);
+        } else {
+            trace_enable_events(nv2a_reg_disable);
+        }
     }
 
 #ifdef CONFIG_RENDERDOC

--- a/util/qemu-thread-posix.c
+++ b/util/qemu-thread-posix.c
@@ -22,7 +22,7 @@
 #include <pthread_np.h>
 #endif
 
-static bool name_threads;
+static bool name_threads = true;
 
 void qemu_thread_naming(bool enable)
 {


### PR DESCRIPTION
Hardware transparently supports passing 2D textures to operations that are intended to operate on cubemaps. This change introduces a remapping function to mimic the hardware behavior in cases where the texture sampler does not match the expectations of the texture mode.

Fixes #1622

Tests: https://github.com/abaire/nxdk_pgraph_tests/blob/4a1fde90854f318a4725178c9c6a7f1fcd016d05/src/tests/texture_2d_as_cubemap_tests.cpp#L79
HW results: https://abaire.github.io/nxdk_pgraph_tests_golden_results/results/Texture_2D_as_cubemap/index.html